### PR TITLE
first pass of keyboard support

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -129,6 +129,8 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 //
 //
 //
+//
+//
 
 var DEF_CHECKED_COLOR = '#75C791';
 var DEF_UNCHEKED_COLOR = '#bfcbd9';
@@ -406,7 +408,15 @@ module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c
     class: _vm.className,
     style: (_vm.style),
     attrs: {
+      "tabindex": "0",
       "role": "checkbox"
+    },
+    on: {
+      "keydown": function($event) {
+        if (!('button' in $event) && _vm._k($event.keyCode, "space", 32)) { return null; }
+        $event.stopPropagation();
+        _vm.toggle($event)
+      }
     }
   }, [_c('input', {
     staticClass: "v-switch-input",

--- a/src/Button.vue
+++ b/src/Button.vue
@@ -1,6 +1,8 @@
 <template>
 <label :class="className"
        :style="style"
+       tabindex="0"
+       @keydown.space.stop="toggle"
        role="checkbox">
   <input type="checkbox"
          class="v-switch-input"


### PR DESCRIPTION
* adds `tabindex="0"` to the labels, allowing `tab` and `shift+tab` navigation
* adds `toggle` when pressing `space`, to simulate native keyboard toggling
* note: I didn't add any focus styles, so right now this uses native ones. not sure if you want to add some.
* fixes #21

![19245c02-f9ef-4127-8565-37d0c7712367-608-00018ebfc9f7bb71](https://user-images.githubusercontent.com/447522/30287542-7bc349d6-96f3-11e7-90b3-d0b6672493c0.gif)
