### PR TITLE
Interpret undefined value as false

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -270,7 +270,7 @@ var px = function px(v) {
   },
   data: function data() {
     return {
-      toggled: this.value
+      toggled: !!this.value
     };
   },
 

--- a/dist/ssr.index.js
+++ b/dist/ssr.index.js
@@ -270,7 +270,7 @@ var px = function px(v) {
   },
   data: function data() {
     return {
-      toggled: this.value
+      toggled: !!this.value
     };
   },
 

--- a/src/Button.vue
+++ b/src/Button.vue
@@ -177,7 +177,7 @@ export default {
   },
   data () {
     return {
-      toggled: this.value
+      toggled: !!this.value
     }
   },
   methods: {


### PR DESCRIPTION
Currently, if I pass `undefined`  as value to the toggle button, it internally throws an error due to the call of `toString()` on undefined for the value of `ariaChecked`. This fix converts it to a boolean instead and renders that as a string automatically.