### PR TITLE
Always interpret undefined/null value as false

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -269,7 +269,7 @@ var px = function px(v) {
   watch: {
     value: function value(_value) {
       if (this.sync) {
-        this.toggled = _value;
+        this.toggled = !!_value;
       }
     }
   },

--- a/dist/ssr.index.js
+++ b/dist/ssr.index.js
@@ -269,7 +269,7 @@ var px = function px(v) {
   watch: {
     value: function value(_value) {
       if (this.sync) {
-        this.toggled = _value;
+        this.toggled = !!_value;
       }
     }
   },

--- a/src/Button.vue
+++ b/src/Button.vue
@@ -176,7 +176,7 @@ export default {
   watch: {
     value (value) {
       if (this.sync) {
-        this.toggled = value
+        this.toggled = !!value
       }
     }
   },


### PR DESCRIPTION
This is a follow up PR to #38, in which unfortunately only one of two possible locations where `toggled` is deducted from `value` were addressed. 