### PR TITLE
Don't publish .babelrc file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 demo
+.babelrc


### PR DESCRIPTION
More and more npm packages contain ES2015+ code.
As discussed in this [AMA](https://github.com/sindresorhus/ama/issues/446), this causes a lot of troubles (Uglify and old browsers) for people.

One possible solution is to transpile external dependencies, as discussed in this [issue on create-react-app ](https://github.com/facebookincubator/create-react-app/issues/1125) and implemented in [this pull request](https://github.com/facebookincubator/create-react-app/pull/3776).

This doesn't currently work with vue-js-toggle-button as the .babelrc file is published on npm.

By adding the .babelrc file to .npmignore, the bug would go away once a new version of vue-js-toggle-button is published.

see: [source 1](https://github.com/Akryum/v-tooltip/pull/90) and [source 2](https://github.com/webslides/WebSlides/pull/106) 