### PR TITLE
Update README.md to show how to import component

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install:
 ```bash
 npm install vue-js-toggle-button --save
 ```
-Import:
+Import Plugin:
 ```javascript
 import ToggleButton from 'vue-js-toggle-button'
 Vue.use(ToggleButton)
@@ -35,6 +35,11 @@ Use:
 
 <toggle-button :value="true" 
                :labels="{checked: 'Foo', unchecked: 'Bar'}"/>
+```
+
+If you prefer not to use the plugin you can also import the component directly:
+```javascript
+import ToggleButton from 'vue-js-toggle-button/src/Button'
 ```
 
 ### Properties


### PR DESCRIPTION
The package by default exports a plugin, but it is also useful to document how to import the component directly.