### PR TITLE
Improve accessibility

### DIFF
--- a/src/Button.vue
+++ b/src/Button.vue
@@ -1,7 +1,5 @@
 <template>
-<label role="checkbox"
-       :class="className"
-       :aria-checked="ariaChecked">
+<label :class="className">
   <input type="checkbox"
          class="v-switch-input"
          :name="name"
@@ -265,7 +263,10 @@ $margin: 3px;
   cursor: pointer;
 
   .v-switch-input {
-    display: none;
+    opacity: 0;
+    position: absolute;
+    width: 1px;
+    height: 1px;
   }
 
   .v-switch-label {

--- a/src/Button.vue
+++ b/src/Button.vue
@@ -68,7 +68,7 @@ export default {
       type: [String, Object],
       validator (value) {
         return typeof value === 'object'
-          ? (value.checked || value.unchecked)
+          ? (value.checked || value.unchecked || value.disabled)
           : typeof value === 'string'
       }
     },

--- a/src/Button.vue
+++ b/src/Button.vue
@@ -109,10 +109,6 @@ export default {
       return ['vue-js-switch', { toggled, disabled }]
     },
 
-    ariaChecked () {
-      return this.toggled.toString()
-    },
-
     coreStyle () {
       return {
         width: px(this.width),


### PR DESCRIPTION
- Resolve https://github.com/euvl/vue-js-toggle-button/issues/82
- Fix color property validator

As mentioned in the issue, the `<input/>` is still accessible/focusable and natively reacts to keyboard events.
However I think each screen reader has different rules (like browsers) and [this post](https://stackoverflow.com/a/43206381/9826498) says ChromeVox screen reader doesn't read content with 0 opacity.
Another solution could be to set opacity to 0.001. Anyway the `<input/>` has a `position: absolute`, so it's hidden by the toggle button (if the color isn't transparent of course).

I didn't notice any regression on the demo page but if you have time, you can double check 😄 