### PR TITLE
Adds the ability to use slots for labels

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -20,6 +20,9 @@
     "vue-loader": "^11.1.4",
     "vue-template-compiler": "^2.2.1",
     "webpack": "^2.2.0",
-    "webpack-dev-server": "^2.2.0"
+    "webpack-dev-server": "^2.2.0",
+    "@fortawesome/fontawesome-svg-core": "^1.2.8",
+    "@fortawesome/free-solid-svg-icons": "^5.5.0",
+    "@fortawesome/vue-fontawesome": "^0.1.2"
   }
 }

--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -47,6 +47,22 @@
           :color="{checked: '#7DCE94', unchecked: '#82C7EB'}"
           :width="80"
           :switchColor="{checked: 'linear-gradient(red, yellow)', unchecked: '#F2C00B'}"/>
+
+        <toggle-button :labels="true">
+          <template slot="checked">
+            <fa icon='check'></fa>
+          </template>
+          <template slot="unchecked">
+            <fa icon='times'></fa>
+          </template>
+        </toggle-button>
+
+        <toggle-button :width="120" :labels="{checked: '', unchecked: 'FA Icon Support'}">
+          <template slot="checked">
+            <fa icon='check'></fa>
+          </template>
+        </toggle-button>
+
       </div>
       <div style="padding-top: 20px;">
         <toggle-button

--- a/demo/src/main.js
+++ b/demo/src/main.js
@@ -1,6 +1,12 @@
 import Vue from 'vue'
 import App from './App.vue'
 import ToggleButton from 'plugin'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faCheck, faTimes } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+
+library.add([faCheck, faTimes])
+Vue.component('fa', FontAwesomeIcon)
 
 Vue.use(ToggleButton)
 

--- a/src/Button.vue
+++ b/src/Button.vue
@@ -13,12 +13,19 @@
   <template v-if="labels">
     <span class="v-switch-label v-left"
           :style="labelStyle"
-          v-if="toggled"
-          v-html="labelChecked"/>
+          v-if="toggled">
+      <slot name="checked">
+        <template>{{labelChecked}}</template>
+      </slot>
+    </span>
+
     <span class="v-switch-label v-right"
           :style="labelStyle"
-          v-else
-          v-html="labelUnchecked"/>
+          v-else>
+      <slot name="unchecked">
+        <template>{{labelUnchecked}}</template>
+      </slot>
+    </span>
   </template>
 </label>
 </template>


### PR DESCRIPTION
Adds support for two new slots, checked and unchecked.  Places the label html inside of a slot to act as a default for that slot.

This allows for use of Vue components as labels,  I've updated the example to use the vue-fontawesome library. https://github.com/FortAwesome/vue-fontawesome

![screen shot 2018-11-15 at 4 18 32 pm](https://user-images.githubusercontent.com/4029685/48589846-26791800-e8f2-11e8-883f-25f644950603.png)
![screen shot 2018-11-15 at 4 18 37 pm](https://user-images.githubusercontent.com/4029685/48589847-2711ae80-e8f2-11e8-8ec5-66af312fddfb.png)
