### PR TITLE
add ToggleButton export and remove unneeded imports/args

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,12 @@
-import Vue from 'vue'
-import Button from './Button.vue'
+import ToggleButton from './Button.vue'
 
 const plugin = {
-  install(Vue, options) {
-  	Vue.component('ToggleButton', Button)
+  install(Vue) {
+  	Vue.component('ToggleButton', ToggleButton)
   }
 }
 
 export default plugin
+export {
+  ToggleButton
+}


### PR DESCRIPTION
This removes the need for users to install the `sass-loader` when importing the component.

Both `import ToggleButton from 'vue-js-toggle-button';` and `import { ToggleButton } from 'vue-js-toggle-button';` with the latter exporting the component, not the install function.