### PR TITLE
Change translate3d to translate

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -73,7 +73,7 @@ return /******/ (function(modules) { // webpackBootstrap
 /******/ 	__webpack_require__.p = "/dist/";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 2);
+/******/ 	return __webpack_require__(__webpack_require__.s = 9);
 /******/ })
 /************************************************************************/
 /******/ ([
@@ -82,13 +82,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /* styles */
-__webpack_require__(8)
+__webpack_require__(6)
 
-var Component = __webpack_require__(6)(
+var Component = __webpack_require__(4)(
   /* script */
   __webpack_require__(1),
   /* template */
-  __webpack_require__(7),
+  __webpack_require__(5),
   /* scopeId */
   "data-v-25adc6c0",
   /* cssModules */
@@ -104,9 +104,7 @@ module.exports = Component.exports
 
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils__ = __webpack_require__(3);
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils__ = __webpack_require__(10);
 //
 //
 //
@@ -152,11 +150,11 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 
 
 
-var DEFAULT_COLOR_CHECKED = '#75c791';
-var DEFAULT_COLOR_UNCHECKED = '#bfcbd9';
-var DEFAULT_LABEL_CHECKED = 'on';
-var DEFAULT_LABEL_UNCHECKED = 'off';
-var DEFAULT_SWITCH_COLOR = '#fff';
+const DEFAULT_COLOR_CHECKED = '#75c791';
+const DEFAULT_COLOR_UNCHECKED = '#bfcbd9';
+const DEFAULT_LABEL_CHECKED = 'on';
+const DEFAULT_LABEL_UNCHECKED = 'off';
+const DEFAULT_SWITCH_COLOR = '#fff';
 
 /* harmony default export */ __webpack_exports__["default"] = ({
   name: 'ToggleButton',
@@ -185,13 +183,13 @@ var DEFAULT_SWITCH_COLOR = '#fff';
     },
     color: {
       type: [String, Object],
-      validator: function validator(value) {
+      validator(value) {
         return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["a" /* isString */])(value) || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'checked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'unchecked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'disabled');
       }
     },
     switchColor: {
       type: [String, Object],
-      validator: function validator(value) {
+      validator(value) {
         return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["a" /* isString */])(value) || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'checked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'unchecked');
       }
     },
@@ -202,8 +200,8 @@ var DEFAULT_SWITCH_COLOR = '#fff';
     labels: {
       type: [Boolean, Object],
       default: false,
-      validator: function validator(value) {
-        return (typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object' ? value.checked || value.unchecked : typeof value === 'boolean';
+      validator(value) {
+        return typeof value === 'object' ? value.checked || value.unchecked : typeof value === 'boolean';
       }
     },
     height: {
@@ -223,17 +221,16 @@ var DEFAULT_SWITCH_COLOR = '#fff';
     }
   },
   computed: {
-    className: function className() {
-      var toggled = this.toggled,
-          disabled = this.disabled;
-
+    className() {
+      let { toggled, disabled } = this;
 
       return ['vue-js-switch', {
-        toggled: toggled,
-        disabled: disabled
+        toggled,
+        disabled
       }];
     },
-    coreStyle: function coreStyle() {
+
+    coreStyle() {
       return {
         width: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.width),
         height: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.height),
@@ -241,37 +238,41 @@ var DEFAULT_SWITCH_COLOR = '#fff';
         borderRadius: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(Math.round(this.height / 2))
       };
     },
-    buttonRadius: function buttonRadius() {
+
+    buttonRadius() {
       return this.height - this.margin * 2;
     },
-    distance: function distance() {
+
+    distance() {
       return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.width - this.height + this.margin);
     },
-    buttonStyle: function buttonStyle() {
-      var transition = 'transform ' + this.speed + 'ms';
-      var margin = __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.margin);
 
-      var transform = this.toggled ? __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["d" /* translate3d */])(this.distance, margin) : __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["d" /* translate3d */])(margin, margin);
+    buttonStyle() {
+      const transition = `transform ${this.speed}ms`;
+      const margin = __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.margin);
 
-      var background = this.switchColor ? this.switchColorCurrent : null;
+      const transform = this.toggled ? __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["d" /* translate */])(this.distance, margin) : __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["d" /* translate */])(margin, margin);
+
+      const background = this.switchColor ? this.switchColorCurrent : null;
 
       return {
         width: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.buttonRadius),
         height: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.buttonRadius),
-        transition: transition,
-        transform: transform,
-        background: background
+        transition,
+        transform,
+        background
       };
     },
-    labelStyle: function labelStyle() {
+
+    labelStyle() {
       return {
         lineHeight: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.height),
         fontSize: this.fontSize ? __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.fontSize) : null
       };
     },
-    colorChecked: function colorChecked() {
-      var color = this.color;
 
+    colorChecked() {
+      let { color } = this;
 
       if (!__webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* isObject */])(color)) {
         return color || DEFAULT_COLOR_CHECKED;
@@ -279,30 +280,37 @@ var DEFAULT_SWITCH_COLOR = '#fff';
 
       return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(color, 'checked', DEFAULT_COLOR_CHECKED);
     },
-    colorUnchecked: function colorUnchecked() {
+
+    colorUnchecked() {
       return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.color, 'unchecked', DEFAULT_COLOR_UNCHECKED);
     },
-    colorDisabled: function colorDisabled() {
+
+    colorDisabled() {
       return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.color, 'disabled', this.colorCurrent);
     },
-    colorCurrent: function colorCurrent() {
+
+    colorCurrent() {
       return this.toggled ? this.colorChecked : this.colorUnchecked;
     },
-    labelChecked: function labelChecked() {
+
+    labelChecked() {
       return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.labels, 'checked', DEFAULT_LABEL_CHECKED);
     },
-    labelUnchecked: function labelUnchecked() {
+
+    labelUnchecked() {
       return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.labels, 'unchecked', DEFAULT_LABEL_UNCHECKED);
     },
-    switchColorChecked: function switchColorChecked() {
+
+    switchColorChecked() {
       return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.switchColor, 'checked', DEFAULT_SWITCH_COLOR);
     },
-    switchColorUnchecked: function switchColorUnchecked() {
+
+    switchColorUnchecked() {
       return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.switchColor, 'unchecked', DEFAULT_SWITCH_COLOR);
     },
-    switchColorCurrent: function switchColorCurrent() {
-      var switchColor = this.switchColor;
 
+    switchColorCurrent() {
+      let { switchColor } = this;
 
       if (!__webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* isObject */])(this.switchColor)) {
         return this.switchColor || DEFAULT_SWITCH_COLOR;
@@ -310,23 +318,23 @@ var DEFAULT_SWITCH_COLOR = '#fff';
 
       return this.toggled ? this.switchColorChecked : this.switchColorUnchecked;
     }
+
   },
   watch: {
-    value: function value(_value) {
+    value(value) {
       if (this.sync) {
-        this.toggled = !!_value;
+        this.toggled = !!value;
       }
     }
   },
-  data: function data() {
+  data() {
     return {
       toggled: !!this.value
     };
   },
-
   methods: {
-    toggle: function toggle(event) {
-      var toggled = !this.toggled;
+    toggle(event) {
+      const toggled = !this.toggled;
 
       if (!this.sync) {
         this.toggled = toggled;
@@ -344,79 +352,9 @@ var DEFAULT_SWITCH_COLOR = '#fff';
 
 /***/ }),
 /* 2 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__Button_vue__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__Button_vue___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__Button_vue__);
-/* harmony reexport (default from non-hamory) */ __webpack_require__.d(__webpack_exports__, "ToggleButton", function() { return __WEBPACK_IMPORTED_MODULE_0__Button_vue___default.a; });
-
-
-var installed = false;
-
-/* harmony default export */ __webpack_exports__["default"] = ({
-  install: function install(Vue) {
-    if (installed) {
-      return;
-    }
-
-    Vue.component('ToggleButton', __WEBPACK_IMPORTED_MODULE_0__Button_vue___default.a);
-    installed = true;
-  }
-});
-
-
-
-/***/ }),
-/* 3 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return isString; });
-/* unused harmony export isBoolean */
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "e", function() { return isObject; });
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "b", function() { return has; });
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "f", function() { return get; });
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "c", function() { return px; });
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "d", function() { return translate3d; });
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
-var isString = function isString(value) {
-  return typeof value === 'string';
-};
-
-var isBoolean = function isBoolean(value) {
-  return typeof value === 'boolean';
-};
-
-var isObject = function isObject(value) {
-  return (typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object';
-};
-
-var has = function has(object, key) {
-  return isObject(object) && object.hasOwnProperty(key);
-};
-
-var get = function get(object, key, defaultValue) {
-  return has(object, key) ? object[key] : defaultValue;
-};
-
-var px = function px(value) {
-  return value + 'px';
-};
-
-var translate3d = function translate3d(x, y) {
-  var z = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : '0px';
-
-  return 'translate3d(' + x + ', ' + y + ', ' + z + ')';
-};
-
-/***/ }),
-/* 4 */
 /***/ (function(module, exports, __webpack_require__) {
 
-exports = module.exports = __webpack_require__(5)();
+exports = module.exports = __webpack_require__(3)();
 // imports
 
 
@@ -427,7 +365,7 @@ exports.push([module.i, ".vue-js-switch[data-v-25adc6c0]{display:inline-block;po
 
 
 /***/ }),
-/* 5 */
+/* 3 */
 /***/ (function(module, exports) {
 
 /*
@@ -483,7 +421,7 @@ module.exports = function() {
 
 
 /***/ }),
-/* 6 */
+/* 4 */
 /***/ (function(module, exports) {
 
 // this module is a runtime utility for cleaner component module output and will
@@ -540,7 +478,7 @@ module.exports = function normalizeComponent (
 
 
 /***/ }),
-/* 7 */
+/* 5 */
 /***/ (function(module, exports) {
 
 module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;
@@ -582,20 +520,20 @@ module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c
 },staticRenderFns: []}
 
 /***/ }),
-/* 8 */
+/* 6 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // style-loader: Adds some css to the DOM by adding a <style> tag
 
 // load the styles
-var content = __webpack_require__(4);
+var content = __webpack_require__(2);
 if(typeof content === 'string') content = [[module.i, content, '']];
 if(content.locals) module.exports = content.locals;
 // add the styles to the DOM
-var update = __webpack_require__(9)("2283861f", content, true);
+var update = __webpack_require__(7)("2283861f", content, true);
 
 /***/ }),
-/* 9 */
+/* 7 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /*
@@ -614,7 +552,7 @@ if (typeof DEBUG !== 'undefined' && DEBUG) {
   ) }
 }
 
-var listToStyles = __webpack_require__(10)
+var listToStyles = __webpack_require__(8)
 
 /*
 type StyleObject = {
@@ -816,7 +754,7 @@ function applyToTag (styleElement, obj) {
 
 
 /***/ }),
-/* 10 */
+/* 8 */
 /***/ (function(module, exports) {
 
 /**
@@ -846,6 +784,80 @@ module.exports = function listToStyles (parentId, list) {
   }
   return styles
 }
+
+
+/***/ }),
+/* 9 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__Button_vue__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__Button_vue___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__Button_vue__);
+/* harmony reexport (default from non-hamory) */ __webpack_require__.d(__webpack_exports__, "ToggleButton", function() { return __WEBPACK_IMPORTED_MODULE_0__Button_vue___default.a; });
+
+
+let installed = false
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  install(Vue) {
+    if (installed) {
+      return
+    }
+    
+    Vue.component('ToggleButton', __WEBPACK_IMPORTED_MODULE_0__Button_vue___default.a)
+    installed = true
+  }
+});
+
+
+
+
+/***/ }),
+/* 10 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+const isString = (value) => {
+  return typeof value === 'string'
+}
+/* harmony export (immutable) */ __webpack_exports__["a"] = isString;
+
+
+const isBoolean = (value) => {
+  return typeof value === 'boolean'
+}
+/* unused harmony export isBoolean */
+
+
+const isObject = (value) => {
+  return typeof value === 'object'
+}
+/* harmony export (immutable) */ __webpack_exports__["e"] = isObject;
+
+
+const has = (object, key) => {
+  return isObject(object) && object.hasOwnProperty(key)
+}
+/* harmony export (immutable) */ __webpack_exports__["b"] = has;
+
+
+const get = (object, key, defaultValue) => {
+  return has(object, key) ? object[key] : defaultValue
+}
+/* harmony export (immutable) */ __webpack_exports__["f"] = get;
+
+
+const px = value => {
+  return `${value}px`
+}
+/* harmony export (immutable) */ __webpack_exports__["c"] = px;
+
+
+const translate = (x, y) => {
+  return `translate(${x}, ${y})`
+}
+/* harmony export (immutable) */ __webpack_exports__["d"] = translate;
 
 
 /***/ })

--- a/dist/ssr.index.js
+++ b/dist/ssr.index.js
@@ -73,7 +73,7 @@ return /******/ (function(modules) { // webpackBootstrap
 /******/ 	__webpack_require__.p = "/dist/";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 2);
+/******/ 	return __webpack_require__(__webpack_require__.s = 9);
 /******/ })
 /************************************************************************/
 /******/ ([
@@ -82,13 +82,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /* styles */
-__webpack_require__(8)
+__webpack_require__(6)
 
-var Component = __webpack_require__(6)(
+var Component = __webpack_require__(4)(
   /* script */
   __webpack_require__(1),
   /* template */
-  __webpack_require__(7),
+  __webpack_require__(5),
   /* scopeId */
   "data-v-25adc6c0",
   /* cssModules */
@@ -104,9 +104,7 @@ module.exports = Component.exports
 
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils__ = __webpack_require__(3);
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils__ = __webpack_require__(10);
 //
 //
 //
@@ -152,11 +150,11 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 
 
 
-var DEFAULT_COLOR_CHECKED = '#75c791';
-var DEFAULT_COLOR_UNCHECKED = '#bfcbd9';
-var DEFAULT_LABEL_CHECKED = 'on';
-var DEFAULT_LABEL_UNCHECKED = 'off';
-var DEFAULT_SWITCH_COLOR = '#fff';
+const DEFAULT_COLOR_CHECKED = '#75c791';
+const DEFAULT_COLOR_UNCHECKED = '#bfcbd9';
+const DEFAULT_LABEL_CHECKED = 'on';
+const DEFAULT_LABEL_UNCHECKED = 'off';
+const DEFAULT_SWITCH_COLOR = '#fff';
 
 /* harmony default export */ __webpack_exports__["default"] = ({
   name: 'ToggleButton',
@@ -185,13 +183,13 @@ var DEFAULT_SWITCH_COLOR = '#fff';
     },
     color: {
       type: [String, Object],
-      validator: function validator(value) {
+      validator(value) {
         return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["a" /* isString */])(value) || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'checked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'unchecked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'disabled');
       }
     },
     switchColor: {
       type: [String, Object],
-      validator: function validator(value) {
+      validator(value) {
         return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["a" /* isString */])(value) || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'checked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'unchecked');
       }
     },
@@ -202,8 +200,8 @@ var DEFAULT_SWITCH_COLOR = '#fff';
     labels: {
       type: [Boolean, Object],
       default: false,
-      validator: function validator(value) {
-        return (typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object' ? value.checked || value.unchecked : typeof value === 'boolean';
+      validator(value) {
+        return typeof value === 'object' ? value.checked || value.unchecked : typeof value === 'boolean';
       }
     },
     height: {
@@ -223,17 +221,16 @@ var DEFAULT_SWITCH_COLOR = '#fff';
     }
   },
   computed: {
-    className: function className() {
-      var toggled = this.toggled,
-          disabled = this.disabled;
-
+    className() {
+      let { toggled, disabled } = this;
 
       return ['vue-js-switch', {
-        toggled: toggled,
-        disabled: disabled
+        toggled,
+        disabled
       }];
     },
-    coreStyle: function coreStyle() {
+
+    coreStyle() {
       return {
         width: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.width),
         height: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.height),
@@ -241,37 +238,41 @@ var DEFAULT_SWITCH_COLOR = '#fff';
         borderRadius: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(Math.round(this.height / 2))
       };
     },
-    buttonRadius: function buttonRadius() {
+
+    buttonRadius() {
       return this.height - this.margin * 2;
     },
-    distance: function distance() {
+
+    distance() {
       return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.width - this.height + this.margin);
     },
-    buttonStyle: function buttonStyle() {
-      var transition = 'transform ' + this.speed + 'ms';
-      var margin = __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.margin);
 
-      var transform = this.toggled ? __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["d" /* translate3d */])(this.distance, margin) : __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["d" /* translate3d */])(margin, margin);
+    buttonStyle() {
+      const transition = `transform ${this.speed}ms`;
+      const margin = __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.margin);
 
-      var background = this.switchColor ? this.switchColorCurrent : null;
+      const transform = this.toggled ? __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["d" /* translate */])(this.distance, margin) : __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["d" /* translate */])(margin, margin);
+
+      const background = this.switchColor ? this.switchColorCurrent : null;
 
       return {
         width: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.buttonRadius),
         height: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.buttonRadius),
-        transition: transition,
-        transform: transform,
-        background: background
+        transition,
+        transform,
+        background
       };
     },
-    labelStyle: function labelStyle() {
+
+    labelStyle() {
       return {
         lineHeight: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.height),
         fontSize: this.fontSize ? __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.fontSize) : null
       };
     },
-    colorChecked: function colorChecked() {
-      var color = this.color;
 
+    colorChecked() {
+      let { color } = this;
 
       if (!__webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* isObject */])(color)) {
         return color || DEFAULT_COLOR_CHECKED;
@@ -279,30 +280,37 @@ var DEFAULT_SWITCH_COLOR = '#fff';
 
       return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(color, 'checked', DEFAULT_COLOR_CHECKED);
     },
-    colorUnchecked: function colorUnchecked() {
+
+    colorUnchecked() {
       return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.color, 'unchecked', DEFAULT_COLOR_UNCHECKED);
     },
-    colorDisabled: function colorDisabled() {
+
+    colorDisabled() {
       return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.color, 'disabled', this.colorCurrent);
     },
-    colorCurrent: function colorCurrent() {
+
+    colorCurrent() {
       return this.toggled ? this.colorChecked : this.colorUnchecked;
     },
-    labelChecked: function labelChecked() {
+
+    labelChecked() {
       return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.labels, 'checked', DEFAULT_LABEL_CHECKED);
     },
-    labelUnchecked: function labelUnchecked() {
+
+    labelUnchecked() {
       return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.labels, 'unchecked', DEFAULT_LABEL_UNCHECKED);
     },
-    switchColorChecked: function switchColorChecked() {
+
+    switchColorChecked() {
       return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.switchColor, 'checked', DEFAULT_SWITCH_COLOR);
     },
-    switchColorUnchecked: function switchColorUnchecked() {
+
+    switchColorUnchecked() {
       return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.switchColor, 'unchecked', DEFAULT_SWITCH_COLOR);
     },
-    switchColorCurrent: function switchColorCurrent() {
-      var switchColor = this.switchColor;
 
+    switchColorCurrent() {
+      let { switchColor } = this;
 
       if (!__webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* isObject */])(this.switchColor)) {
         return this.switchColor || DEFAULT_SWITCH_COLOR;
@@ -310,23 +318,23 @@ var DEFAULT_SWITCH_COLOR = '#fff';
 
       return this.toggled ? this.switchColorChecked : this.switchColorUnchecked;
     }
+
   },
   watch: {
-    value: function value(_value) {
+    value(value) {
       if (this.sync) {
-        this.toggled = !!_value;
+        this.toggled = !!value;
       }
     }
   },
-  data: function data() {
+  data() {
     return {
       toggled: !!this.value
     };
   },
-
   methods: {
-    toggle: function toggle(event) {
-      var toggled = !this.toggled;
+    toggle(event) {
+      const toggled = !this.toggled;
 
       if (!this.sync) {
         this.toggled = toggled;
@@ -344,79 +352,9 @@ var DEFAULT_SWITCH_COLOR = '#fff';
 
 /***/ }),
 /* 2 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__Button_vue__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__Button_vue___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__Button_vue__);
-/* harmony reexport (default from non-hamory) */ __webpack_require__.d(__webpack_exports__, "ToggleButton", function() { return __WEBPACK_IMPORTED_MODULE_0__Button_vue___default.a; });
-
-
-var installed = false;
-
-/* harmony default export */ __webpack_exports__["default"] = ({
-  install: function install(Vue) {
-    if (installed) {
-      return;
-    }
-
-    Vue.component('ToggleButton', __WEBPACK_IMPORTED_MODULE_0__Button_vue___default.a);
-    installed = true;
-  }
-});
-
-
-
-/***/ }),
-/* 3 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return isString; });
-/* unused harmony export isBoolean */
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "e", function() { return isObject; });
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "b", function() { return has; });
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "f", function() { return get; });
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "c", function() { return px; });
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "d", function() { return translate3d; });
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
-var isString = function isString(value) {
-  return typeof value === 'string';
-};
-
-var isBoolean = function isBoolean(value) {
-  return typeof value === 'boolean';
-};
-
-var isObject = function isObject(value) {
-  return (typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object';
-};
-
-var has = function has(object, key) {
-  return isObject(object) && object.hasOwnProperty(key);
-};
-
-var get = function get(object, key, defaultValue) {
-  return has(object, key) ? object[key] : defaultValue;
-};
-
-var px = function px(value) {
-  return value + 'px';
-};
-
-var translate3d = function translate3d(x, y) {
-  var z = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : '0px';
-
-  return 'translate3d(' + x + ', ' + y + ', ' + z + ')';
-};
-
-/***/ }),
-/* 4 */
 /***/ (function(module, exports, __webpack_require__) {
 
-exports = module.exports = __webpack_require__(5)();
+exports = module.exports = __webpack_require__(3)();
 // imports
 
 
@@ -427,7 +365,7 @@ exports.push([module.i, ".vue-js-switch[data-v-25adc6c0]{display:inline-block;po
 
 
 /***/ }),
-/* 5 */
+/* 3 */
 /***/ (function(module, exports) {
 
 /*
@@ -483,7 +421,7 @@ module.exports = function() {
 
 
 /***/ }),
-/* 6 */
+/* 4 */
 /***/ (function(module, exports) {
 
 // this module is a runtime utility for cleaner component module output and will
@@ -540,7 +478,7 @@ module.exports = function normalizeComponent (
 
 
 /***/ }),
-/* 7 */
+/* 5 */
 /***/ (function(module, exports) {
 
 module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;
@@ -582,23 +520,23 @@ module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c
 },staticRenderFns: []}
 
 /***/ }),
-/* 8 */
+/* 6 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // style-loader: Adds some css to the DOM by adding a <style> tag
 
 // load the styles
-var content = __webpack_require__(4);
+var content = __webpack_require__(2);
 if(typeof content === 'string') content = [[module.i, content, '']];
 if(content.locals) module.exports = content.locals;
 // add CSS to SSR context
-__webpack_require__(9)("2283861f", content, true);
+__webpack_require__(7)("2283861f", content, true);
 
 /***/ }),
-/* 9 */
+/* 7 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var listToStyles = __webpack_require__(10)
+var listToStyles = __webpack_require__(8)
 
 module.exports = function (parentId, list, isProduction) {
   if (typeof __VUE_SSR_CONTEXT__ !== 'undefined') {
@@ -680,7 +618,7 @@ function renderStyles (styles) {
 
 
 /***/ }),
-/* 10 */
+/* 8 */
 /***/ (function(module, exports) {
 
 /**
@@ -710,6 +648,80 @@ module.exports = function listToStyles (parentId, list) {
   }
   return styles
 }
+
+
+/***/ }),
+/* 9 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__Button_vue__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__Button_vue___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__Button_vue__);
+/* harmony reexport (default from non-hamory) */ __webpack_require__.d(__webpack_exports__, "ToggleButton", function() { return __WEBPACK_IMPORTED_MODULE_0__Button_vue___default.a; });
+
+
+let installed = false
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  install(Vue) {
+    if (installed) {
+      return
+    }
+    
+    Vue.component('ToggleButton', __WEBPACK_IMPORTED_MODULE_0__Button_vue___default.a)
+    installed = true
+  }
+});
+
+
+
+
+/***/ }),
+/* 10 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+const isString = (value) => {
+  return typeof value === 'string'
+}
+/* harmony export (immutable) */ __webpack_exports__["a"] = isString;
+
+
+const isBoolean = (value) => {
+  return typeof value === 'boolean'
+}
+/* unused harmony export isBoolean */
+
+
+const isObject = (value) => {
+  return typeof value === 'object'
+}
+/* harmony export (immutable) */ __webpack_exports__["e"] = isObject;
+
+
+const has = (object, key) => {
+  return isObject(object) && object.hasOwnProperty(key)
+}
+/* harmony export (immutable) */ __webpack_exports__["b"] = has;
+
+
+const get = (object, key, defaultValue) => {
+  return has(object, key) ? object[key] : defaultValue
+}
+/* harmony export (immutable) */ __webpack_exports__["f"] = get;
+
+
+const px = value => {
+  return `${value}px`
+}
+/* harmony export (immutable) */ __webpack_exports__["c"] = px;
+
+
+const translate = (x, y) => {
+  return `translate(${x}, ${y})`
+}
+/* harmony export (immutable) */ __webpack_exports__["d"] = translate;
 
 
 /***/ })

--- a/src/Button.vue
+++ b/src/Button.vue
@@ -41,7 +41,7 @@
 </template>
 
 <script>
-import { isString, isObject, isBoolean, has, get, translate3d, px } from './utils'
+import { isString, isObject, isBoolean, has, get, translate, px } from './utils'
 
 const DEFAULT_COLOR_CHECKED = '#75c791'
 const DEFAULT_COLOR_UNCHECKED = '#bfcbd9'
@@ -154,8 +154,8 @@ export default {
       const margin = px(this.margin)
 
       const transform = this.toggled
-        ? translate3d(this.distance, margin)
-        : translate3d(margin, margin)
+        ? translate(this.distance, margin)
+        : translate(margin, margin)
 
       const background = this.switchColor
         ? this.switchColorCurrent

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,6 +22,6 @@ export const px = value => {
   return `${value}px`
 }
 
-export const translate3d = (x, y, z = '0px') => {
-  return `translate3d(${x}, ${y}, ${z})`
+export const translate = (x, y) => {
+  return `translate(${x}, ${y})`
 }


### PR DESCRIPTION
translate3d causes overflow scrolling with mouse wheel to stop working in Google Chrome. Change the css property transformation to translate. 

The z-axis was hardcoded to '0', so there is no need to use the translate3d property when the regular translate will work fine.