### PR TITLE
feat: add focus indicator

### DIFF
--- a/src/Button.vue
+++ b/src/Button.vue
@@ -278,6 +278,10 @@ export default {
     height: 1px;
   }
 
+  .v-switch-input:focus + .v-switch-core {
+    box-shadow: 0 0 2px 1px #888;
+  }
+
   .v-switch-label {
     position: absolute;
     top: 0;


### PR DESCRIPTION
There should be indicator for button when it is focused, so that people who are using keyboard to navigate a site would know where they are, this make the component more accessible.
If you merge this consider updating docs too(if needed).