### PR TITLE
Add color label new prop and minor refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://badge.fury.io/js/vue-js-toggle-button.svg">
 </span> <span>
   <img src="https://img.shields.io/npm/dm/vue-js-toggle-button.svg">
-</span> 
+</span>
 
 # Vue.js toggle/switch button.
 
@@ -71,6 +71,7 @@ Vue.component('ToggleButton', ToggleButton)
 | speed           | Number            | 300        | Transition time for the animation   |
 | disabled        | Boolean           | false      | Button does not react on mouse events |
 | color           | [String, Object]  | `#75C791`  | If `String` - color of the button when checked <br>If `Object` - colors for the button when checked/unchecked or disabled<br>Example: `{checked: '#00FF00', unchecked: '#FF0000', disabled: '#CCCCCC'}`  |
+| colorLabel      | [String, Object]  | `#75C791`  | If `String` - color of the label when checked <br>If `Object` - colors for the label when checked/unchecked or disabled<br>Example: `{checked: '#00FF00', unchecked: '#FF0000', disabled: '#CCCCCC'}`  |
 | css-colors       | Boolean           | false      | If `true` - deactivates the setting of colors through inline styles in favor of using CSS styling |
 | labels          | [Boolean, Object] | false      | If `Boolean` - shows/hides default labels ("on" and "off") <br>If `Object` - sets custom labels for both states. <br>Example: `{checked: 'Foo', unchecked: 'Bar'}`   |
 | switch-color     | [String, Object]  | `#BFCBD9`  | If `String` - color or background property of the switch when checked <br>If `Object` - colors or background property for the switch when checked/uncheked <br>Example: `{checked: '#25EF02', unchecked: 'linear-gradient(red, yellow)'}`   |

--- a/dist/index.js
+++ b/dist/index.js
@@ -73,299 +73,113 @@ return /******/ (function(modules) { // webpackBootstrap
 /******/ 	__webpack_require__.p = "/dist/";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 9);
+/******/ 	return __webpack_require__(__webpack_require__.s = 8);
 /******/ })
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
+"use strict";
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return isString; });
+/* unused harmony export isBoolean */
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "f", function() { return isObject; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "b", function() { return has; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "e", function() { return get; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "c", function() { return px; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "d", function() { return translate; });
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-/* styles */
-__webpack_require__(6)
+var isString = function isString(value) {
+  return typeof value === 'string';
+};
 
-var Component = __webpack_require__(4)(
-  /* script */
-  __webpack_require__(1),
-  /* template */
-  __webpack_require__(5),
-  /* scopeId */
-  "data-v-25adc6c0",
-  /* cssModules */
-  null
-)
+var isBoolean = function isBoolean(value) {
+  return typeof value === 'boolean';
+};
 
-module.exports = Component.exports
+var isObject = function isObject(value) {
+  return (typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object';
+};
 
+var has = function has(object, key) {
+  return isObject(object) && object.hasOwnProperty(key);
+};
+
+var get = function get(object, key, defaultValue) {
+  return has(object, key) ? object[key] : defaultValue;
+};
+
+var px = function px(value) {
+  return value + 'px';
+};
+
+var translate = function translate(x, y) {
+  return 'translate(' + x + ', ' + y + ')';
+};
 
 /***/ }),
 /* 1 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils__ = __webpack_require__(10);
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils__ = __webpack_require__(0);
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 
 
-const DEFAULT_COLOR_CHECKED = '#75c791';
-const DEFAULT_COLOR_UNCHECKED = '#bfcbd9';
-const DEFAULT_LABEL_CHECKED = 'on';
-const DEFAULT_LABEL_UNCHECKED = 'off';
-const DEFAULT_SWITCH_COLOR = '#fff';
-
-/* harmony default export */ __webpack_exports__["default"] = ({
-  name: 'ToggleButton',
+/* harmony default export */ __webpack_exports__["a"] = ({
   props: {
-    value: {
-      type: Boolean,
-      default: false
-    },
-    name: {
-      type: String
-    },
     disabled: {
       type: Boolean,
       default: false
     },
-    tag: {
-      type: String
-    },
-    sync: {
-      type: Boolean,
-      default: false
-    },
-    speed: {
-      type: Number,
-      default: 300
-    },
     color: {
       type: [String, Object],
-      validator(value) {
+      validator: function validator(value) {
         return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["a" /* isString */])(value) || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'checked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'unchecked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'disabled');
       }
-    },
-    switchColor: {
-      type: [String, Object],
-      validator(value) {
-        return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["a" /* isString */])(value) || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'checked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'unchecked');
-      }
-    },
-    cssColors: {
-      type: Boolean,
-      default: false
     },
     labels: {
       type: [Boolean, Object],
       default: false,
-      validator(value) {
-        return typeof value === 'object' ? value.checked || value.unchecked : typeof value === 'boolean';
+      validator: function validator(value) {
+        return (typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object' ? value.checked || value.unchecked : typeof value === 'boolean';
       }
     },
     height: {
       type: Number,
       default: 22
     },
-    width: {
-      type: Number,
-      default: 50
-    },
-    margin: {
-      type: Number,
-      default: 3
-    },
     fontSize: {
       type: Number
     }
   },
   computed: {
-    className() {
-      let { toggled, disabled } = this;
+    colorChecked: function colorChecked() {
+      var color = this.color;
 
-      return ['vue-js-switch', {
-        toggled,
-        disabled
-      }];
-    },
 
-    coreStyle() {
-      return {
-        width: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.width),
-        height: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.height),
-        backgroundColor: this.cssColors ? null : this.disabled ? this.colorDisabled : this.colorCurrent,
-        borderRadius: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(Math.round(this.height / 2))
-      };
-    },
-
-    buttonRadius() {
-      return this.height - this.margin * 2;
-    },
-
-    distance() {
-      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.width - this.height + this.margin);
-    },
-
-    buttonStyle() {
-      const transition = `transform ${this.speed}ms`;
-      const margin = __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.margin);
-
-      const transform = this.toggled ? __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["d" /* translate */])(this.distance, margin) : __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["d" /* translate */])(margin, margin);
-
-      const background = this.switchColor ? this.switchColorCurrent : null;
-
-      return {
-        width: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.buttonRadius),
-        height: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.buttonRadius),
-        transition,
-        transform,
-        background
-      };
-    },
-
-    labelStyle() {
-      return {
-        lineHeight: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.height),
-        fontSize: this.fontSize ? __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.fontSize) : null
-      };
-    },
-
-    colorChecked() {
-      let { color } = this;
-
-      if (!__webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* isObject */])(color)) {
-        return color || DEFAULT_COLOR_CHECKED;
+      if (!__webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* isObject */])(color)) {
+        return color || this.defaultColorChecked;
       }
 
-      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(color, 'checked', DEFAULT_COLOR_CHECKED);
+      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* get */])(color, 'checked', this.defaultColorChecked);
     },
-
-    colorUnchecked() {
-      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.color, 'unchecked', DEFAULT_COLOR_UNCHECKED);
+    colorUnchecked: function colorUnchecked() {
+      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* get */])(this.color, 'unchecked', this.defaultColorUnchecked);
     },
-
-    colorDisabled() {
-      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.color, 'disabled', this.colorCurrent);
+    colorDisabled: function colorDisabled() {
+      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* get */])(this.color, 'disabled', this.colorCurrent);
     },
-
-    colorCurrent() {
+    colorCurrent: function colorCurrent() {
       return this.toggled ? this.colorChecked : this.colorUnchecked;
-    },
-
-    labelChecked() {
-      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.labels, 'checked', DEFAULT_LABEL_CHECKED);
-    },
-
-    labelUnchecked() {
-      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.labels, 'unchecked', DEFAULT_LABEL_UNCHECKED);
-    },
-
-    switchColorChecked() {
-      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.switchColor, 'checked', DEFAULT_SWITCH_COLOR);
-    },
-
-    switchColorUnchecked() {
-      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.switchColor, 'unchecked', DEFAULT_SWITCH_COLOR);
-    },
-
-    switchColorCurrent() {
-      let { switchColor } = this;
-
-      if (!__webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* isObject */])(this.switchColor)) {
-        return this.switchColor || DEFAULT_SWITCH_COLOR;
-      }
-
-      return this.toggled ? this.switchColorChecked : this.switchColorUnchecked;
-    }
-
-  },
-  watch: {
-    value(value) {
-      if (this.sync) {
-        this.toggled = !!value;
-      }
-    }
-  },
-  data() {
-    return {
-      toggled: !!this.value
-    };
-  },
-  methods: {
-    toggle(event) {
-      const toggled = !this.toggled;
-
-      if (!this.sync) {
-        this.toggled = toggled;
-      }
-
-      this.$emit('input', toggled);
-      this.$emit('change', {
-        value: toggled,
-        tag: this.tag,
-        srcEvent: event
-      });
     }
   }
 });
 
 /***/ }),
 /* 2 */
-/***/ (function(module, exports, __webpack_require__) {
-
-exports = module.exports = __webpack_require__(3)();
-// imports
-
-
-// module
-exports.push([module.i, ".vue-js-switch[data-v-25adc6c0]{display:inline-block;position:relative;vertical-align:middle;user-select:none;font-size:10px;cursor:pointer}.vue-js-switch .v-switch-input[data-v-25adc6c0]{opacity:0;position:absolute;width:1px;height:1px}.vue-js-switch .v-switch-label[data-v-25adc6c0]{position:absolute;top:0;font-weight:600;color:#fff;z-index:1}.vue-js-switch .v-switch-label.v-left[data-v-25adc6c0]{left:10px}.vue-js-switch .v-switch-label.v-right[data-v-25adc6c0]{right:10px}.vue-js-switch .v-switch-core[data-v-25adc6c0]{display:block;position:relative;box-sizing:border-box;outline:0;margin:0;transition:border-color .3s,background-color .3s;user-select:none}.vue-js-switch .v-switch-core .v-switch-button[data-v-25adc6c0]{display:block;position:absolute;overflow:hidden;top:0;left:0;border-radius:100%;background-color:#fff;z-index:2}.vue-js-switch.disabled[data-v-25adc6c0]{pointer-events:none;opacity:.6}", ""]);
-
-// exports
-
-
-/***/ }),
-/* 3 */
 /***/ (function(module, exports) {
 
 /*
@@ -421,7 +235,7 @@ module.exports = function() {
 
 
 /***/ }),
-/* 4 */
+/* 3 */
 /***/ (function(module, exports) {
 
 // this module is a runtime utility for cleaner component module output and will
@@ -478,62 +292,7 @@ module.exports = function normalizeComponent (
 
 
 /***/ }),
-/* 5 */
-/***/ (function(module, exports) {
-
-module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;
-  return _c('label', {
-    class: _vm.className
-  }, [_c('input', {
-    staticClass: "v-switch-input",
-    attrs: {
-      "type": "checkbox",
-      "name": _vm.name,
-      "disabled": _vm.disabled
-    },
-    domProps: {
-      "checked": _vm.value
-    },
-    on: {
-      "change": function($event) {
-        $event.stopPropagation();
-        return _vm.toggle($event)
-      }
-    }
-  }), _vm._v(" "), _c('div', {
-    staticClass: "v-switch-core",
-    style: (_vm.coreStyle)
-  }, [_c('div', {
-    staticClass: "v-switch-button",
-    style: (_vm.buttonStyle)
-  })]), _vm._v(" "), (_vm.labels) ? [(_vm.toggled) ? _c('span', {
-    staticClass: "v-switch-label v-left",
-    style: (_vm.labelStyle)
-  }, [_vm._t("checked", [
-    [_vm._v(_vm._s(_vm.labelChecked))]
-  ])], 2) : _c('span', {
-    staticClass: "v-switch-label v-right",
-    style: (_vm.labelStyle)
-  }, [_vm._t("unchecked", [
-    [_vm._v(_vm._s(_vm.labelUnchecked))]
-  ])], 2)] : _vm._e()], 2)
-},staticRenderFns: []}
-
-/***/ }),
-/* 6 */
-/***/ (function(module, exports, __webpack_require__) {
-
-// style-loader: Adds some css to the DOM by adding a <style> tag
-
-// load the styles
-var content = __webpack_require__(2);
-if(typeof content === 'string') content = [[module.i, content, '']];
-if(content.locals) module.exports = content.locals;
-// add the styles to the DOM
-var update = __webpack_require__(7)("2283861f", content, true);
-
-/***/ }),
-/* 7 */
+/* 4 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /*
@@ -552,7 +311,7 @@ if (typeof DEBUG !== 'undefined' && DEBUG) {
   ) }
 }
 
-var listToStyles = __webpack_require__(8)
+var listToStyles = __webpack_require__(16)
 
 /*
 type StyleObject = {
@@ -754,7 +513,466 @@ function applyToTag (styleElement, obj) {
 
 
 /***/ }),
+/* 5 */
+/***/ (function(module, exports, __webpack_require__) {
+
+
+/* styles */
+__webpack_require__(14)
+
+var Component = __webpack_require__(3)(
+  /* script */
+  __webpack_require__(6),
+  /* template */
+  __webpack_require__(12),
+  /* scopeId */
+  "data-v-25adc6c0",
+  /* cssModules */
+  null
+)
+
+module.exports = Component.exports
+
+
+/***/ }),
+/* 6 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__general_mixin__ = __webpack_require__(1);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__ButtonLabel_vue__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__ButtonLabel_vue___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__ButtonLabel_vue__);
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+
+
+
+
+
+var DEFAULT_SWITCH_COLOR = '#fff';
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  name: 'ToggleButton',
+  mixins: [__WEBPACK_IMPORTED_MODULE_1__general_mixin__["a" /* default */]],
+  components: {
+    ToggleButtonLabel: __WEBPACK_IMPORTED_MODULE_2__ButtonLabel_vue___default.a
+  },
+  props: {
+    value: {
+      type: Boolean,
+      default: false
+    },
+    name: {
+      type: String
+    },
+    tag: {
+      type: String
+    },
+    sync: {
+      type: Boolean,
+      default: false
+    },
+    speed: {
+      type: Number,
+      default: 300
+    },
+    switchColor: {
+      type: [String, Object],
+      validator: function validator(value) {
+        return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["a" /* isString */])(value) || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'checked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'unchecked');
+      }
+    },
+    colorLabel: {
+      type: [String, Object],
+      validator: function validator(value) {
+        return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["a" /* isString */])(value) || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'checked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'unchecked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'disabled');
+      }
+    },
+    cssColors: {
+      type: Boolean,
+      default: false
+    },
+    width: {
+      type: Number,
+      default: 50
+    },
+    margin: {
+      type: Number,
+      default: 3
+    }
+  },
+  computed: {
+    className: function className() {
+      var toggled = this.toggled,
+          disabled = this.disabled;
+
+
+      return ['vue-js-switch', {
+        toggled: toggled,
+        disabled: disabled
+      }];
+    },
+    coreStyle: function coreStyle() {
+      return {
+        width: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.width),
+        height: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.height),
+        backgroundColor: this.cssColors ? null : this.disabled ? this.colorDisabled : this.colorCurrent,
+        borderRadius: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(Math.round(this.height / 2))
+      };
+    },
+    buttonRadius: function buttonRadius() {
+      return this.height - this.margin * 2;
+    },
+    distance: function distance() {
+      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.width - this.height + this.margin);
+    },
+    buttonStyle: function buttonStyle() {
+      var transition = 'transform ' + this.speed + 'ms';
+      var margin = __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.margin);
+
+      var transform = this.toggled ? __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["d" /* translate */])(this.distance, margin) : __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["d" /* translate */])(margin, margin);
+
+      var background = this.switchColor ? this.switchColorCurrent : null;
+
+      return {
+        width: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.buttonRadius),
+        height: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.buttonRadius),
+        transition: transition,
+        transform: transform,
+        background: background
+      };
+    },
+    switchColorChecked: function switchColorChecked() {
+      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* get */])(this.switchColor, 'checked', DEFAULT_SWITCH_COLOR);
+    },
+    switchColorUnchecked: function switchColorUnchecked() {
+      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* get */])(this.switchColor, 'unchecked', DEFAULT_SWITCH_COLOR);
+    },
+    switchColorCurrent: function switchColorCurrent() {
+      var switchColor = this.switchColor;
+
+
+      if (!__webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* isObject */])(this.switchColor)) {
+        return this.switchColor || DEFAULT_SWITCH_COLOR;
+      }
+
+      return this.toggled ? this.switchColorChecked : this.switchColorUnchecked;
+    }
+  },
+  watch: {
+    value: function value(_value) {
+      if (this.sync) {
+        this.toggled = !!_value;
+      }
+    }
+  },
+  data: function data() {
+    return {
+      toggled: !!this.value,
+      defaultColorChecked: '#75c791',
+      defaultColorUnchecked: '#bfcbd9'
+    };
+  },
+
+  methods: {
+    toggle: function toggle(event) {
+      var toggled = !this.toggled;
+
+      if (!this.sync) {
+        this.toggled = toggled;
+      }
+
+      this.$emit('input', toggled);
+      this.$emit('change', {
+        value: toggled,
+        tag: this.tag,
+        srcEvent: event
+      });
+    }
+  }
+});
+
+/***/ }),
+/* 7 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__general_mixin__ = __webpack_require__(1);
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+
+
+
+
+var DEFAULT_LABEL_CHECKED = 'on';
+var DEFAULT_LABEL_UNCHECKED = 'off';
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  name: 'ToggleButtonLabel',
+  mixins: [__WEBPACK_IMPORTED_MODULE_1__general_mixin__["a" /* default */]],
+  props: {
+    checked: {
+      type: Boolean,
+      default: false
+    },
+    toggled: {
+      type: Boolean,
+      default: false
+    }
+  },
+  computed: {
+    labelStyle: function labelStyle() {
+      return {
+        lineHeight: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.height),
+        fontSize: this.fontSize ? __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.fontSize) : null,
+        color: this.disabled ? this.colorDisabled : this.colorCurrent
+      };
+    },
+    className: function className() {
+      return this.checked ? 'v-left' : 'v-right';
+    },
+    labelText: function labelText() {
+      return this.checked ? this.labelChecked : this.labelUnchecked;
+    },
+    labelChecked: function labelChecked() {
+      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* get */])(this.labels, 'checked', DEFAULT_LABEL_CHECKED);
+    },
+    labelUnchecked: function labelUnchecked() {
+      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* get */])(this.labels, 'unchecked', DEFAULT_LABEL_UNCHECKED);
+    }
+  },
+  data: function data() {
+    return {
+      defaultColorChecked: '#ffffff',
+      defaultColorUnchecked: '#ffffff'
+    };
+  }
+});
+
+/***/ }),
 /* 8 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__Button_vue__ = __webpack_require__(5);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__Button_vue___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__Button_vue__);
+/* harmony reexport (default from non-hamory) */ __webpack_require__.d(__webpack_exports__, "ToggleButton", function() { return __WEBPACK_IMPORTED_MODULE_0__Button_vue___default.a; });
+
+
+var installed = false;
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  install: function install(Vue) {
+    if (installed) {
+      return;
+    }
+
+    Vue.component('ToggleButton', __WEBPACK_IMPORTED_MODULE_0__Button_vue___default.a);
+    installed = true;
+  }
+});
+
+
+
+/***/ }),
+/* 9 */
+/***/ (function(module, exports, __webpack_require__) {
+
+exports = module.exports = __webpack_require__(2)();
+// imports
+
+
+// module
+exports.push([module.i, ".vue-js-switch[data-v-25adc6c0]{display:inline-block;position:relative;vertical-align:middle;user-select:none;font-size:10px;cursor:pointer}.vue-js-switch .v-switch-input[data-v-25adc6c0]{opacity:0;position:absolute;width:1px;height:1px}.vue-js-switch .v-switch-core[data-v-25adc6c0]{display:block;position:relative;box-sizing:border-box;outline:0;margin:0;transition:border-color .3s,background-color .3s;user-select:none}.vue-js-switch .v-switch-core .v-switch-button[data-v-25adc6c0]{display:block;position:absolute;overflow:hidden;top:0;left:0;border-radius:100%;background-color:#fff;z-index:2}.vue-js-switch.disabled[data-v-25adc6c0]{pointer-events:none;opacity:.6}", ""]);
+
+// exports
+
+
+/***/ }),
+/* 10 */
+/***/ (function(module, exports, __webpack_require__) {
+
+exports = module.exports = __webpack_require__(2)();
+// imports
+
+
+// module
+exports.push([module.i, ".vue-js-switch .v-switch-label[data-v-791efc44]{position:absolute;top:0;font-weight:600;color:#fff;z-index:1}.vue-js-switch .v-switch-label.v-left[data-v-791efc44]{left:10px}.vue-js-switch .v-switch-label.v-right[data-v-791efc44]{right:10px}", ""]);
+
+// exports
+
+
+/***/ }),
+/* 11 */
+/***/ (function(module, exports, __webpack_require__) {
+
+
+/* styles */
+__webpack_require__(15)
+
+var Component = __webpack_require__(3)(
+  /* script */
+  __webpack_require__(7),
+  /* template */
+  __webpack_require__(13),
+  /* scopeId */
+  "data-v-791efc44",
+  /* cssModules */
+  null
+)
+
+module.exports = Component.exports
+
+
+/***/ }),
+/* 12 */
+/***/ (function(module, exports) {
+
+module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;
+  return _c('label', {
+    class: _vm.className
+  }, [_c('input', {
+    staticClass: "v-switch-input",
+    attrs: {
+      "type": "checkbox",
+      "name": _vm.name,
+      "disabled": _vm.disabled
+    },
+    domProps: {
+      "checked": _vm.value
+    },
+    on: {
+      "change": function($event) {
+        $event.stopPropagation();
+        return _vm.toggle($event)
+      }
+    }
+  }), _vm._v(" "), _c('div', {
+    staticClass: "v-switch-core",
+    style: (_vm.coreStyle)
+  }, [_c('div', {
+    staticClass: "v-switch-button",
+    style: (_vm.buttonStyle)
+  })]), _vm._v(" "), (_vm.labels) ? [(_vm.toggled) ? _c('toggle-button-label', {
+    attrs: {
+      "labels": _vm.labels,
+      "disabled": _vm.disabled,
+      "height": _vm.height,
+      "font-size": _vm.fontSize,
+      "color": _vm.colorLabel,
+      "toggled": "",
+      "checked": ""
+    }
+  }) : _c('toggle-button-label', {
+    attrs: {
+      "labels": _vm.labels,
+      "disabled": _vm.disabled,
+      "height": _vm.height,
+      "font-size": _vm.fontSize,
+      "color": _vm.colorLabel,
+      "checked": false,
+      "toggled": false
+    }
+  })] : _vm._e()], 2)
+},staticRenderFns: []}
+
+/***/ }),
+/* 13 */
+/***/ (function(module, exports) {
+
+module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;
+  return _c('span', {
+    staticClass: "v-switch-label",
+    class: _vm.className,
+    style: (_vm.labelStyle)
+  }, [
+    [_vm._v(_vm._s(_vm.labelText))]
+  ], 2)
+},staticRenderFns: []}
+
+/***/ }),
+/* 14 */
+/***/ (function(module, exports, __webpack_require__) {
+
+// style-loader: Adds some css to the DOM by adding a <style> tag
+
+// load the styles
+var content = __webpack_require__(9);
+if(typeof content === 'string') content = [[module.i, content, '']];
+if(content.locals) module.exports = content.locals;
+// add the styles to the DOM
+var update = __webpack_require__(4)("2283861f", content, true);
+
+/***/ }),
+/* 15 */
+/***/ (function(module, exports, __webpack_require__) {
+
+// style-loader: Adds some css to the DOM by adding a <style> tag
+
+// load the styles
+var content = __webpack_require__(10);
+if(typeof content === 'string') content = [[module.i, content, '']];
+if(content.locals) module.exports = content.locals;
+// add the styles to the DOM
+var update = __webpack_require__(4)("5dfb8cf4", content, true);
+
+/***/ }),
+/* 16 */
 /***/ (function(module, exports) {
 
 /**
@@ -784,80 +1002,6 @@ module.exports = function listToStyles (parentId, list) {
   }
   return styles
 }
-
-
-/***/ }),
-/* 9 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__Button_vue__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__Button_vue___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__Button_vue__);
-/* harmony reexport (default from non-hamory) */ __webpack_require__.d(__webpack_exports__, "ToggleButton", function() { return __WEBPACK_IMPORTED_MODULE_0__Button_vue___default.a; });
-
-
-let installed = false
-
-/* harmony default export */ __webpack_exports__["default"] = ({
-  install(Vue) {
-    if (installed) {
-      return
-    }
-    
-    Vue.component('ToggleButton', __WEBPACK_IMPORTED_MODULE_0__Button_vue___default.a)
-    installed = true
-  }
-});
-
-
-
-
-/***/ }),
-/* 10 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-const isString = (value) => {
-  return typeof value === 'string'
-}
-/* harmony export (immutable) */ __webpack_exports__["a"] = isString;
-
-
-const isBoolean = (value) => {
-  return typeof value === 'boolean'
-}
-/* unused harmony export isBoolean */
-
-
-const isObject = (value) => {
-  return typeof value === 'object'
-}
-/* harmony export (immutable) */ __webpack_exports__["e"] = isObject;
-
-
-const has = (object, key) => {
-  return isObject(object) && object.hasOwnProperty(key)
-}
-/* harmony export (immutable) */ __webpack_exports__["b"] = has;
-
-
-const get = (object, key, defaultValue) => {
-  return has(object, key) ? object[key] : defaultValue
-}
-/* harmony export (immutable) */ __webpack_exports__["f"] = get;
-
-
-const px = value => {
-  return `${value}px`
-}
-/* harmony export (immutable) */ __webpack_exports__["c"] = px;
-
-
-const translate = (x, y) => {
-  return `translate(${x}, ${y})`
-}
-/* harmony export (immutable) */ __webpack_exports__["d"] = translate;
 
 
 /***/ })

--- a/dist/ssr.index.js
+++ b/dist/ssr.index.js
@@ -73,299 +73,113 @@ return /******/ (function(modules) { // webpackBootstrap
 /******/ 	__webpack_require__.p = "/dist/";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 9);
+/******/ 	return __webpack_require__(__webpack_require__.s = 8);
 /******/ })
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
+"use strict";
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return isString; });
+/* unused harmony export isBoolean */
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "f", function() { return isObject; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "b", function() { return has; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "e", function() { return get; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "c", function() { return px; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "d", function() { return translate; });
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-/* styles */
-__webpack_require__(6)
+var isString = function isString(value) {
+  return typeof value === 'string';
+};
 
-var Component = __webpack_require__(4)(
-  /* script */
-  __webpack_require__(1),
-  /* template */
-  __webpack_require__(5),
-  /* scopeId */
-  "data-v-25adc6c0",
-  /* cssModules */
-  null
-)
+var isBoolean = function isBoolean(value) {
+  return typeof value === 'boolean';
+};
 
-module.exports = Component.exports
+var isObject = function isObject(value) {
+  return (typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object';
+};
 
+var has = function has(object, key) {
+  return isObject(object) && object.hasOwnProperty(key);
+};
+
+var get = function get(object, key, defaultValue) {
+  return has(object, key) ? object[key] : defaultValue;
+};
+
+var px = function px(value) {
+  return value + 'px';
+};
+
+var translate = function translate(x, y) {
+  return 'translate(' + x + ', ' + y + ')';
+};
 
 /***/ }),
 /* 1 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils__ = __webpack_require__(10);
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils__ = __webpack_require__(0);
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 
 
-const DEFAULT_COLOR_CHECKED = '#75c791';
-const DEFAULT_COLOR_UNCHECKED = '#bfcbd9';
-const DEFAULT_LABEL_CHECKED = 'on';
-const DEFAULT_LABEL_UNCHECKED = 'off';
-const DEFAULT_SWITCH_COLOR = '#fff';
-
-/* harmony default export */ __webpack_exports__["default"] = ({
-  name: 'ToggleButton',
+/* harmony default export */ __webpack_exports__["a"] = ({
   props: {
-    value: {
-      type: Boolean,
-      default: false
-    },
-    name: {
-      type: String
-    },
     disabled: {
       type: Boolean,
       default: false
     },
-    tag: {
-      type: String
-    },
-    sync: {
-      type: Boolean,
-      default: false
-    },
-    speed: {
-      type: Number,
-      default: 300
-    },
     color: {
       type: [String, Object],
-      validator(value) {
+      validator: function validator(value) {
         return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["a" /* isString */])(value) || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'checked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'unchecked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'disabled');
       }
-    },
-    switchColor: {
-      type: [String, Object],
-      validator(value) {
-        return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["a" /* isString */])(value) || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'checked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'unchecked');
-      }
-    },
-    cssColors: {
-      type: Boolean,
-      default: false
     },
     labels: {
       type: [Boolean, Object],
       default: false,
-      validator(value) {
-        return typeof value === 'object' ? value.checked || value.unchecked : typeof value === 'boolean';
+      validator: function validator(value) {
+        return (typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object' ? value.checked || value.unchecked : typeof value === 'boolean';
       }
     },
     height: {
       type: Number,
       default: 22
     },
-    width: {
-      type: Number,
-      default: 50
-    },
-    margin: {
-      type: Number,
-      default: 3
-    },
     fontSize: {
       type: Number
     }
   },
   computed: {
-    className() {
-      let { toggled, disabled } = this;
+    colorChecked: function colorChecked() {
+      var color = this.color;
 
-      return ['vue-js-switch', {
-        toggled,
-        disabled
-      }];
-    },
 
-    coreStyle() {
-      return {
-        width: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.width),
-        height: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.height),
-        backgroundColor: this.cssColors ? null : this.disabled ? this.colorDisabled : this.colorCurrent,
-        borderRadius: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(Math.round(this.height / 2))
-      };
-    },
-
-    buttonRadius() {
-      return this.height - this.margin * 2;
-    },
-
-    distance() {
-      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.width - this.height + this.margin);
-    },
-
-    buttonStyle() {
-      const transition = `transform ${this.speed}ms`;
-      const margin = __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.margin);
-
-      const transform = this.toggled ? __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["d" /* translate */])(this.distance, margin) : __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["d" /* translate */])(margin, margin);
-
-      const background = this.switchColor ? this.switchColorCurrent : null;
-
-      return {
-        width: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.buttonRadius),
-        height: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.buttonRadius),
-        transition,
-        transform,
-        background
-      };
-    },
-
-    labelStyle() {
-      return {
-        lineHeight: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.height),
-        fontSize: this.fontSize ? __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.fontSize) : null
-      };
-    },
-
-    colorChecked() {
-      let { color } = this;
-
-      if (!__webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* isObject */])(color)) {
-        return color || DEFAULT_COLOR_CHECKED;
+      if (!__webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* isObject */])(color)) {
+        return color || this.defaultColorChecked;
       }
 
-      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(color, 'checked', DEFAULT_COLOR_CHECKED);
+      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* get */])(color, 'checked', this.defaultColorChecked);
     },
-
-    colorUnchecked() {
-      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.color, 'unchecked', DEFAULT_COLOR_UNCHECKED);
+    colorUnchecked: function colorUnchecked() {
+      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* get */])(this.color, 'unchecked', this.defaultColorUnchecked);
     },
-
-    colorDisabled() {
-      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.color, 'disabled', this.colorCurrent);
+    colorDisabled: function colorDisabled() {
+      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* get */])(this.color, 'disabled', this.colorCurrent);
     },
-
-    colorCurrent() {
+    colorCurrent: function colorCurrent() {
       return this.toggled ? this.colorChecked : this.colorUnchecked;
-    },
-
-    labelChecked() {
-      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.labels, 'checked', DEFAULT_LABEL_CHECKED);
-    },
-
-    labelUnchecked() {
-      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.labels, 'unchecked', DEFAULT_LABEL_UNCHECKED);
-    },
-
-    switchColorChecked() {
-      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.switchColor, 'checked', DEFAULT_SWITCH_COLOR);
-    },
-
-    switchColorUnchecked() {
-      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* get */])(this.switchColor, 'unchecked', DEFAULT_SWITCH_COLOR);
-    },
-
-    switchColorCurrent() {
-      let { switchColor } = this;
-
-      if (!__webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* isObject */])(this.switchColor)) {
-        return this.switchColor || DEFAULT_SWITCH_COLOR;
-      }
-
-      return this.toggled ? this.switchColorChecked : this.switchColorUnchecked;
-    }
-
-  },
-  watch: {
-    value(value) {
-      if (this.sync) {
-        this.toggled = !!value;
-      }
-    }
-  },
-  data() {
-    return {
-      toggled: !!this.value
-    };
-  },
-  methods: {
-    toggle(event) {
-      const toggled = !this.toggled;
-
-      if (!this.sync) {
-        this.toggled = toggled;
-      }
-
-      this.$emit('input', toggled);
-      this.$emit('change', {
-        value: toggled,
-        tag: this.tag,
-        srcEvent: event
-      });
     }
   }
 });
 
 /***/ }),
 /* 2 */
-/***/ (function(module, exports, __webpack_require__) {
-
-exports = module.exports = __webpack_require__(3)();
-// imports
-
-
-// module
-exports.push([module.i, ".vue-js-switch[data-v-25adc6c0]{display:inline-block;position:relative;vertical-align:middle;user-select:none;font-size:10px;cursor:pointer}.vue-js-switch .v-switch-input[data-v-25adc6c0]{opacity:0;position:absolute;width:1px;height:1px}.vue-js-switch .v-switch-label[data-v-25adc6c0]{position:absolute;top:0;font-weight:600;color:#fff;z-index:1}.vue-js-switch .v-switch-label.v-left[data-v-25adc6c0]{left:10px}.vue-js-switch .v-switch-label.v-right[data-v-25adc6c0]{right:10px}.vue-js-switch .v-switch-core[data-v-25adc6c0]{display:block;position:relative;box-sizing:border-box;outline:0;margin:0;transition:border-color .3s,background-color .3s;user-select:none}.vue-js-switch .v-switch-core .v-switch-button[data-v-25adc6c0]{display:block;position:absolute;overflow:hidden;top:0;left:0;border-radius:100%;background-color:#fff;z-index:2}.vue-js-switch.disabled[data-v-25adc6c0]{pointer-events:none;opacity:.6}", ""]);
-
-// exports
-
-
-/***/ }),
-/* 3 */
 /***/ (function(module, exports) {
 
 /*
@@ -421,7 +235,7 @@ module.exports = function() {
 
 
 /***/ }),
-/* 4 */
+/* 3 */
 /***/ (function(module, exports) {
 
 // this module is a runtime utility for cleaner component module output and will
@@ -478,65 +292,10 @@ module.exports = function normalizeComponent (
 
 
 /***/ }),
-/* 5 */
-/***/ (function(module, exports) {
-
-module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;
-  return _c('label', {
-    class: _vm.className
-  }, [_c('input', {
-    staticClass: "v-switch-input",
-    attrs: {
-      "type": "checkbox",
-      "name": _vm.name,
-      "disabled": _vm.disabled
-    },
-    domProps: {
-      "checked": _vm.value
-    },
-    on: {
-      "change": function($event) {
-        $event.stopPropagation();
-        return _vm.toggle($event)
-      }
-    }
-  }), _vm._v(" "), _c('div', {
-    staticClass: "v-switch-core",
-    style: (_vm.coreStyle)
-  }, [_c('div', {
-    staticClass: "v-switch-button",
-    style: (_vm.buttonStyle)
-  })]), _vm._v(" "), (_vm.labels) ? [(_vm.toggled) ? _c('span', {
-    staticClass: "v-switch-label v-left",
-    style: (_vm.labelStyle)
-  }, [_vm._t("checked", [
-    [_vm._v(_vm._s(_vm.labelChecked))]
-  ])], 2) : _c('span', {
-    staticClass: "v-switch-label v-right",
-    style: (_vm.labelStyle)
-  }, [_vm._t("unchecked", [
-    [_vm._v(_vm._s(_vm.labelUnchecked))]
-  ])], 2)] : _vm._e()], 2)
-},staticRenderFns: []}
-
-/***/ }),
-/* 6 */
+/* 4 */
 /***/ (function(module, exports, __webpack_require__) {
 
-// style-loader: Adds some css to the DOM by adding a <style> tag
-
-// load the styles
-var content = __webpack_require__(2);
-if(typeof content === 'string') content = [[module.i, content, '']];
-if(content.locals) module.exports = content.locals;
-// add CSS to SSR context
-__webpack_require__(7)("2283861f", content, true);
-
-/***/ }),
-/* 7 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var listToStyles = __webpack_require__(8)
+var listToStyles = __webpack_require__(16)
 
 module.exports = function (parentId, list, isProduction) {
   if (typeof __VUE_SSR_CONTEXT__ !== 'undefined') {
@@ -618,7 +377,466 @@ function renderStyles (styles) {
 
 
 /***/ }),
+/* 5 */
+/***/ (function(module, exports, __webpack_require__) {
+
+
+/* styles */
+__webpack_require__(14)
+
+var Component = __webpack_require__(3)(
+  /* script */
+  __webpack_require__(6),
+  /* template */
+  __webpack_require__(12),
+  /* scopeId */
+  "data-v-25adc6c0",
+  /* cssModules */
+  null
+)
+
+module.exports = Component.exports
+
+
+/***/ }),
+/* 6 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__general_mixin__ = __webpack_require__(1);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__ButtonLabel_vue__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__ButtonLabel_vue___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__ButtonLabel_vue__);
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+
+
+
+
+
+var DEFAULT_SWITCH_COLOR = '#fff';
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  name: 'ToggleButton',
+  mixins: [__WEBPACK_IMPORTED_MODULE_1__general_mixin__["a" /* default */]],
+  components: {
+    ToggleButtonLabel: __WEBPACK_IMPORTED_MODULE_2__ButtonLabel_vue___default.a
+  },
+  props: {
+    value: {
+      type: Boolean,
+      default: false
+    },
+    name: {
+      type: String
+    },
+    tag: {
+      type: String
+    },
+    sync: {
+      type: Boolean,
+      default: false
+    },
+    speed: {
+      type: Number,
+      default: 300
+    },
+    switchColor: {
+      type: [String, Object],
+      validator: function validator(value) {
+        return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["a" /* isString */])(value) || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'checked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'unchecked');
+      }
+    },
+    colorLabel: {
+      type: [String, Object],
+      validator: function validator(value) {
+        return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["a" /* isString */])(value) || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'checked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'unchecked') || __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["b" /* has */])(value, 'disabled');
+      }
+    },
+    cssColors: {
+      type: Boolean,
+      default: false
+    },
+    width: {
+      type: Number,
+      default: 50
+    },
+    margin: {
+      type: Number,
+      default: 3
+    }
+  },
+  computed: {
+    className: function className() {
+      var toggled = this.toggled,
+          disabled = this.disabled;
+
+
+      return ['vue-js-switch', {
+        toggled: toggled,
+        disabled: disabled
+      }];
+    },
+    coreStyle: function coreStyle() {
+      return {
+        width: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.width),
+        height: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.height),
+        backgroundColor: this.cssColors ? null : this.disabled ? this.colorDisabled : this.colorCurrent,
+        borderRadius: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(Math.round(this.height / 2))
+      };
+    },
+    buttonRadius: function buttonRadius() {
+      return this.height - this.margin * 2;
+    },
+    distance: function distance() {
+      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.width - this.height + this.margin);
+    },
+    buttonStyle: function buttonStyle() {
+      var transition = 'transform ' + this.speed + 'ms';
+      var margin = __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.margin);
+
+      var transform = this.toggled ? __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["d" /* translate */])(this.distance, margin) : __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["d" /* translate */])(margin, margin);
+
+      var background = this.switchColor ? this.switchColorCurrent : null;
+
+      return {
+        width: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.buttonRadius),
+        height: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.buttonRadius),
+        transition: transition,
+        transform: transform,
+        background: background
+      };
+    },
+    switchColorChecked: function switchColorChecked() {
+      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* get */])(this.switchColor, 'checked', DEFAULT_SWITCH_COLOR);
+    },
+    switchColorUnchecked: function switchColorUnchecked() {
+      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* get */])(this.switchColor, 'unchecked', DEFAULT_SWITCH_COLOR);
+    },
+    switchColorCurrent: function switchColorCurrent() {
+      var switchColor = this.switchColor;
+
+
+      if (!__webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["f" /* isObject */])(this.switchColor)) {
+        return this.switchColor || DEFAULT_SWITCH_COLOR;
+      }
+
+      return this.toggled ? this.switchColorChecked : this.switchColorUnchecked;
+    }
+  },
+  watch: {
+    value: function value(_value) {
+      if (this.sync) {
+        this.toggled = !!_value;
+      }
+    }
+  },
+  data: function data() {
+    return {
+      toggled: !!this.value,
+      defaultColorChecked: '#75c791',
+      defaultColorUnchecked: '#bfcbd9'
+    };
+  },
+
+  methods: {
+    toggle: function toggle(event) {
+      var toggled = !this.toggled;
+
+      if (!this.sync) {
+        this.toggled = toggled;
+      }
+
+      this.$emit('input', toggled);
+      this.$emit('change', {
+        value: toggled,
+        tag: this.tag,
+        srcEvent: event
+      });
+    }
+  }
+});
+
+/***/ }),
+/* 7 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__general_mixin__ = __webpack_require__(1);
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+
+
+
+
+var DEFAULT_LABEL_CHECKED = 'on';
+var DEFAULT_LABEL_UNCHECKED = 'off';
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  name: 'ToggleButtonLabel',
+  mixins: [__WEBPACK_IMPORTED_MODULE_1__general_mixin__["a" /* default */]],
+  props: {
+    checked: {
+      type: Boolean,
+      default: false
+    },
+    toggled: {
+      type: Boolean,
+      default: false
+    }
+  },
+  computed: {
+    labelStyle: function labelStyle() {
+      return {
+        lineHeight: __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.height),
+        fontSize: this.fontSize ? __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["c" /* px */])(this.fontSize) : null,
+        color: this.disabled ? this.colorDisabled : this.colorCurrent
+      };
+    },
+    className: function className() {
+      return this.checked ? 'v-left' : 'v-right';
+    },
+    labelText: function labelText() {
+      return this.checked ? this.labelChecked : this.labelUnchecked;
+    },
+    labelChecked: function labelChecked() {
+      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* get */])(this.labels, 'checked', DEFAULT_LABEL_CHECKED);
+    },
+    labelUnchecked: function labelUnchecked() {
+      return __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_0__utils__["e" /* get */])(this.labels, 'unchecked', DEFAULT_LABEL_UNCHECKED);
+    }
+  },
+  data: function data() {
+    return {
+      defaultColorChecked: '#ffffff',
+      defaultColorUnchecked: '#ffffff'
+    };
+  }
+});
+
+/***/ }),
 /* 8 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__Button_vue__ = __webpack_require__(5);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__Button_vue___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__Button_vue__);
+/* harmony reexport (default from non-hamory) */ __webpack_require__.d(__webpack_exports__, "ToggleButton", function() { return __WEBPACK_IMPORTED_MODULE_0__Button_vue___default.a; });
+
+
+var installed = false;
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  install: function install(Vue) {
+    if (installed) {
+      return;
+    }
+
+    Vue.component('ToggleButton', __WEBPACK_IMPORTED_MODULE_0__Button_vue___default.a);
+    installed = true;
+  }
+});
+
+
+
+/***/ }),
+/* 9 */
+/***/ (function(module, exports, __webpack_require__) {
+
+exports = module.exports = __webpack_require__(2)();
+// imports
+
+
+// module
+exports.push([module.i, ".vue-js-switch[data-v-25adc6c0]{display:inline-block;position:relative;vertical-align:middle;user-select:none;font-size:10px;cursor:pointer}.vue-js-switch .v-switch-input[data-v-25adc6c0]{opacity:0;position:absolute;width:1px;height:1px}.vue-js-switch .v-switch-core[data-v-25adc6c0]{display:block;position:relative;box-sizing:border-box;outline:0;margin:0;transition:border-color .3s,background-color .3s;user-select:none}.vue-js-switch .v-switch-core .v-switch-button[data-v-25adc6c0]{display:block;position:absolute;overflow:hidden;top:0;left:0;border-radius:100%;background-color:#fff;z-index:2}.vue-js-switch.disabled[data-v-25adc6c0]{pointer-events:none;opacity:.6}", ""]);
+
+// exports
+
+
+/***/ }),
+/* 10 */
+/***/ (function(module, exports, __webpack_require__) {
+
+exports = module.exports = __webpack_require__(2)();
+// imports
+
+
+// module
+exports.push([module.i, ".vue-js-switch .v-switch-label[data-v-791efc44]{position:absolute;top:0;font-weight:600;color:#fff;z-index:1}.vue-js-switch .v-switch-label.v-left[data-v-791efc44]{left:10px}.vue-js-switch .v-switch-label.v-right[data-v-791efc44]{right:10px}", ""]);
+
+// exports
+
+
+/***/ }),
+/* 11 */
+/***/ (function(module, exports, __webpack_require__) {
+
+
+/* styles */
+__webpack_require__(15)
+
+var Component = __webpack_require__(3)(
+  /* script */
+  __webpack_require__(7),
+  /* template */
+  __webpack_require__(13),
+  /* scopeId */
+  "data-v-791efc44",
+  /* cssModules */
+  null
+)
+
+module.exports = Component.exports
+
+
+/***/ }),
+/* 12 */
+/***/ (function(module, exports) {
+
+module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;
+  return _c('label', {
+    class: _vm.className
+  }, [_c('input', {
+    staticClass: "v-switch-input",
+    attrs: {
+      "type": "checkbox",
+      "name": _vm.name,
+      "disabled": _vm.disabled
+    },
+    domProps: {
+      "checked": _vm.value
+    },
+    on: {
+      "change": function($event) {
+        $event.stopPropagation();
+        return _vm.toggle($event)
+      }
+    }
+  }), _vm._v(" "), _c('div', {
+    staticClass: "v-switch-core",
+    style: (_vm.coreStyle)
+  }, [_c('div', {
+    staticClass: "v-switch-button",
+    style: (_vm.buttonStyle)
+  })]), _vm._v(" "), (_vm.labels) ? [(_vm.toggled) ? _c('toggle-button-label', {
+    attrs: {
+      "labels": _vm.labels,
+      "disabled": _vm.disabled,
+      "height": _vm.height,
+      "font-size": _vm.fontSize,
+      "color": _vm.colorLabel,
+      "toggled": "",
+      "checked": ""
+    }
+  }) : _c('toggle-button-label', {
+    attrs: {
+      "labels": _vm.labels,
+      "disabled": _vm.disabled,
+      "height": _vm.height,
+      "font-size": _vm.fontSize,
+      "color": _vm.colorLabel,
+      "checked": false,
+      "toggled": false
+    }
+  })] : _vm._e()], 2)
+},staticRenderFns: []}
+
+/***/ }),
+/* 13 */
+/***/ (function(module, exports) {
+
+module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;
+  return _c('span', {
+    staticClass: "v-switch-label",
+    class: _vm.className,
+    style: (_vm.labelStyle)
+  }, [
+    [_vm._v(_vm._s(_vm.labelText))]
+  ], 2)
+},staticRenderFns: []}
+
+/***/ }),
+/* 14 */
+/***/ (function(module, exports, __webpack_require__) {
+
+// style-loader: Adds some css to the DOM by adding a <style> tag
+
+// load the styles
+var content = __webpack_require__(9);
+if(typeof content === 'string') content = [[module.i, content, '']];
+if(content.locals) module.exports = content.locals;
+// add CSS to SSR context
+__webpack_require__(4)("2283861f", content, true);
+
+/***/ }),
+/* 15 */
+/***/ (function(module, exports, __webpack_require__) {
+
+// style-loader: Adds some css to the DOM by adding a <style> tag
+
+// load the styles
+var content = __webpack_require__(10);
+if(typeof content === 'string') content = [[module.i, content, '']];
+if(content.locals) module.exports = content.locals;
+// add CSS to SSR context
+__webpack_require__(4)("5dfb8cf4", content, true);
+
+/***/ }),
+/* 16 */
 /***/ (function(module, exports) {
 
 /**
@@ -648,80 +866,6 @@ module.exports = function listToStyles (parentId, list) {
   }
   return styles
 }
-
-
-/***/ }),
-/* 9 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__Button_vue__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__Button_vue___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__Button_vue__);
-/* harmony reexport (default from non-hamory) */ __webpack_require__.d(__webpack_exports__, "ToggleButton", function() { return __WEBPACK_IMPORTED_MODULE_0__Button_vue___default.a; });
-
-
-let installed = false
-
-/* harmony default export */ __webpack_exports__["default"] = ({
-  install(Vue) {
-    if (installed) {
-      return
-    }
-    
-    Vue.component('ToggleButton', __WEBPACK_IMPORTED_MODULE_0__Button_vue___default.a)
-    installed = true
-  }
-});
-
-
-
-
-/***/ }),
-/* 10 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-const isString = (value) => {
-  return typeof value === 'string'
-}
-/* harmony export (immutable) */ __webpack_exports__["a"] = isString;
-
-
-const isBoolean = (value) => {
-  return typeof value === 'boolean'
-}
-/* unused harmony export isBoolean */
-
-
-const isObject = (value) => {
-  return typeof value === 'object'
-}
-/* harmony export (immutable) */ __webpack_exports__["e"] = isObject;
-
-
-const has = (object, key) => {
-  return isObject(object) && object.hasOwnProperty(key)
-}
-/* harmony export (immutable) */ __webpack_exports__["b"] = has;
-
-
-const get = (object, key, defaultValue) => {
-  return has(object, key) ? object[key] : defaultValue
-}
-/* harmony export (immutable) */ __webpack_exports__["f"] = get;
-
-
-const px = value => {
-  return `${value}px`
-}
-/* harmony export (immutable) */ __webpack_exports__["c"] = px;
-
-
-const translate = (x, y) => {
-  return `translate(${x}, ${y})`
-}
-/* harmony export (immutable) */ __webpack_exports__["d"] = translate;
 
 
 /***/ })

--- a/src/Button.vue
+++ b/src/Button.vue
@@ -18,39 +18,43 @@
     />
   </div>
   <template v-if="labels">
-    <span
-      class="v-switch-label v-left"
-      :style="labelStyle"
+    <toggle-button-label
       v-if="toggled"
-    >
-      <slot name="checked">
-        <template>{{labelChecked}}</template>
-      </slot>
-    </span>
-    <span
-      class="v-switch-label v-right"
-      :style="labelStyle"
+      :labels="labels"
+      :disabled="disabled"
+      :height="height"
+      :font-size="fontSize"
+      :color="colorLabel"
+      toggled
+      checked
+    />
+    <toggle-button-label
       v-else
-    >
-      <slot name="unchecked">
-        <template>{{labelUnchecked}}</template>
-      </slot>
-    </span>
+      :labels="labels"
+      :disabled="disabled"
+      :height="height"
+      :font-size="fontSize"
+      :color="colorLabel"
+      :checked="false"
+      :toggled="false"
+    />
   </template>
 </label>
 </template>
 
 <script>
-import { isString, isObject, isBoolean, has, get, translate, px } from './utils'
+import { isString, isObject, has, get, translate, px } from './utils'
+import generalMixin from './general-mixin'
+import ToggleButtonLabel from './ButtonLabel.vue'
 
-const DEFAULT_COLOR_CHECKED = '#75c791'
-const DEFAULT_COLOR_UNCHECKED = '#bfcbd9'
-const DEFAULT_LABEL_CHECKED = 'on'
-const DEFAULT_LABEL_UNCHECKED = 'off'
 const DEFAULT_SWITCH_COLOR = '#fff'
 
 export default {
   name: 'ToggleButton',
+  mixins: [generalMixin],
+  components: {
+    ToggleButtonLabel
+  },
   props: {
     value: {
       type: Boolean,
@@ -58,10 +62,6 @@ export default {
     },
     name: {
       type: String
-    },
-    disabled: {
-      type: Boolean,
-      default: false
     },
     tag: {
       type: String,
@@ -74,7 +74,15 @@ export default {
       type: Number,
       default: 300
     },
-    color: {
+    switchColor: {
+      type: [String, Object],
+      validator (value) {
+        return isString(value)
+          || has(value, 'checked')
+          || has(value, 'unchecked')
+      }
+    },
+    colorLabel: {
       type: [String, Object],
       validator (value) {
         return isString(value)
@@ -83,30 +91,9 @@ export default {
           || has(value, 'disabled')
       }
     },
-    switchColor: {
-      type: [String, Object],
-      validator (value) {
-        return isString(value) 
-          || has(value, 'checked')
-          || has(value, 'unchecked')
-      }
-    },
     cssColors: {
       type: Boolean,
       default: false
-    },
-    labels: {
-      type: [Boolean, Object],
-      default: false,
-      validator (value) {
-        return typeof value === 'object'
-          ? (value.checked || value.unchecked)
-          : typeof value === 'boolean'
-      }
-    },
-    height: {
-      type: Number,
-      default: 22
     },
     width: {
       type: Number,
@@ -115,15 +102,12 @@ export default {
     margin: {
       type: Number,
       default: 3
-    },
-    fontSize: {
-      type: Number
     }
   },
   computed: {
     className () {
       let { toggled, disabled } = this
-      
+
       return ['vue-js-switch', {
         toggled,
         disabled
@@ -142,7 +126,7 @@ export default {
     },
 
     buttonRadius () {
-      return this.height - this.margin * 2;
+      return this.height - this.margin * 2
     },
 
     distance () {
@@ -168,45 +152,6 @@ export default {
         transform,
         background
       }
-    },
-
-    labelStyle () {
-      return {
-        lineHeight: px(this.height),
-        fontSize: this.fontSize ? px(this.fontSize) : null
-      }
-    },
-
-    colorChecked () {
-      let { color } = this
-
-      if (!isObject(color)) {
-        return color || DEFAULT_COLOR_CHECKED
-      }
-
-      return get(color, 'checked', DEFAULT_COLOR_CHECKED)
-    },
-
-    colorUnchecked () {
-      return get(this.color, 'unchecked', DEFAULT_COLOR_UNCHECKED)
-    },
-
-    colorDisabled () {
-      return get(this.color, 'disabled', this.colorCurrent)
-    },
-
-    colorCurrent () {
-      return this.toggled
-        ? this.colorChecked
-        : this.colorUnchecked
-    },
-
-    labelChecked () {
-      return get(this.labels, 'checked', DEFAULT_LABEL_CHECKED)
-    },
-
-    labelUnchecked () {
-      return get(this.labels, 'unchecked', DEFAULT_LABEL_UNCHECKED)
     },
 
     switchColorChecked () {
@@ -239,30 +184,31 @@ export default {
   },
   data () {
     return {
-      toggled: !!this.value
+      toggled: !!this.value,
+      defaultColorChecked: '#75c791',
+      defaultColorUnchecked: '#bfcbd9'
     }
   },
   methods: {
     toggle(event) {
-      const toggled = !this.toggled;
+      const toggled = !this.toggled
 
       if (!this.sync) {
-        this.toggled = toggled;
+        this.toggled = toggled
       }
 
-      this.$emit('input', toggled);
+      this.$emit('input', toggled)
       this.$emit('change', {
         value: toggled,
         tag: this.tag,
-        srcEvent: event,
-      });
-    },
+        srcEvent: event
+      })
+    }
   }
 }
 </script>
 
 <style lang="scss" scoped>
-
 .vue-js-switch {
   display: inline-block;
   position: relative;
@@ -276,22 +222,6 @@ export default {
     position: absolute;
     width: 1px;
     height: 1px;
-  }
-
-  .v-switch-label {
-    position: absolute;
-    top: 0;
-    font-weight: 600;
-    color: white;
-    z-index: 1;
-
-    &.v-left {
-      left: 10px;
-    }
-
-    &.v-right {
-      right: 10px;
-    }
   }
 
   .v-switch-core {

--- a/src/ButtonLabel.vue
+++ b/src/ButtonLabel.vue
@@ -1,0 +1,83 @@
+<template>
+<span
+  class="v-switch-label"
+  :class="className"
+  :style="labelStyle"
+>
+  <template>{{ labelText }}</template>
+</span>
+</template>
+
+<script>
+import { get, px } from './utils'
+import generalMixin from './general-mixin'
+
+const DEFAULT_LABEL_CHECKED = 'on'
+const DEFAULT_LABEL_UNCHECKED = 'off'
+
+export default {
+  name: 'ToggleButtonLabel',
+  mixins: [generalMixin],
+  props: {
+    checked: {
+      type: Boolean,
+      default: false
+    },
+    toggled: {
+      type: Boolean,
+      default: false
+    }
+  },
+  computed: {
+    labelStyle () {
+      return {
+        lineHeight: px(this.height),
+        fontSize: this.fontSize ? px(this.fontSize) : null,
+        color: (this.disabled ? this.colorDisabled : this.colorCurrent),
+      }
+    },
+
+    className () {
+      return this.checked ? 'v-left' : 'v-right'
+    },
+
+    labelText () {
+      return this.checked ? this.labelChecked : this.labelUnchecked
+    },
+
+    labelChecked () {
+      return get(this.labels, 'checked', DEFAULT_LABEL_CHECKED)
+    },
+
+    labelUnchecked () {
+      return get(this.labels, 'unchecked', DEFAULT_LABEL_UNCHECKED)
+    }
+  },
+  data () {
+    return {
+      defaultColorChecked: '#ffffff',
+      defaultColorUnchecked: '#ffffff'
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.vue-js-switch {
+  .v-switch-label {
+    position: absolute;
+    top: 0;
+    font-weight: 600;
+    color: white;
+    z-index: 1;
+
+    &.v-left {
+      left: 10px;
+    }
+
+    &.v-right {
+      right: 10px;
+    }
+  }
+}
+</style>

--- a/src/general-mixin.js
+++ b/src/general-mixin.js
@@ -1,0 +1,60 @@
+import { isString, isObject, has, get } from './utils'
+
+export default {
+  props: {
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+    color: {
+      type: [String, Object],
+      validator (value) {
+        return isString(value)
+          || has(value, 'checked')
+          || has(value, 'unchecked')
+          || has(value, 'disabled')
+      }
+    },
+    labels: {
+      type: [Boolean, Object],
+      default: false,
+      validator (value) {
+        return typeof value === 'object'
+          ? (value.checked || value.unchecked)
+          : typeof value === 'boolean'
+      }
+    },
+    height: {
+      type: Number,
+      default: 22
+    },
+    fontSize: {
+      type: Number
+    }
+  },
+  computed: {
+    colorChecked () {
+      let { color } = this
+
+      if (!isObject(color)) {
+        return color || this.defaultColorChecked
+      }
+
+      return get(color, 'checked', this.defaultColorChecked)
+    },
+
+    colorUnchecked () {
+      return get(this.color, 'unchecked', this.defaultColorUnchecked)
+    },
+
+    colorDisabled () {
+      return get(this.color, 'disabled', this.colorCurrent)
+    },
+
+    colorCurrent () {
+      return this.toggled
+        ? this.colorChecked
+        : this.colorUnchecked
+    },
+  }
+}


### PR DESCRIPTION
This closes #102 .

This PR adds a new prop called `colorLabel` which is basically the same as the prop `color`, but it changes the color of the label instead of the background.
Since it's using the same logic (computed properties) as the `color` prop, I decided to create a new component specific for labels called `ButtonLabel.vue` (since the other component is called `Button.vue`), and to reuse the logic I created a mixin that is being used by both components. That way all the computed properties and some props are being reused and there isn't no code duplication.
I had to just remove the `consts` and changed to `data` properties, so that the colors are different in between those two components.
For me to reuse those computed properties in a mixin between those two components, the prop color being used differently in each component.
The prop color inside `ButtonLabel.vue` is being used for the label colors (font color).
The prop color inside `Button.vue` is being used for the background color of the toggle.
The `v-switch-label` class was moved to the children component.
The slots was removed for now since there wasn't no used to them.
I also removed an `isBoolean` import that was not being used.
I tested in my browser by importing the dist into another Vue project. 
The `README.md` was also updated.

-----------------------

This is the best I could do for this to be as cleanest as possible, and to have no code duplication.

![image](https://user-images.githubusercontent.com/22016005/77779924-00a96a80-7032-11ea-908d-fcf6c86bca5b.png)
![image](https://user-images.githubusercontent.com/22016005/77779954-0bfc9600-7032-11ea-80fb-207cf5041620.png)


Please let me know what do you think of this. 
Thank you.

